### PR TITLE
Shield async tx auto-rollback from cancellation

### DIFF
--- a/tests/aio/query/test_query_transaction.py
+++ b/tests/aio/query/test_query_transaction.py
@@ -1,11 +1,45 @@
+import asyncio
+from unittest import mock
+
 import pytest
 
 import ydb
 from ydb.aio.query.transaction import QueryTxContext
+from ydb._grpc.grpcwrapper import ydb_query_public_types as _ydb_query_public
 from ydb.query.transaction import QueryTxStateEnum
 
 
 class TestAsyncQueryTransaction:
+    @pytest.mark.asyncio
+    async def test_context_manager_shields_rollback_from_cancellation(self):
+        tx = QueryTxContext(
+            driver=mock.MagicMock(),
+            session=mock.MagicMock(),
+            tx_mode=_ydb_query_public.QuerySerializableReadWrite(),
+        )
+        tx._tx_state._state = QueryTxStateEnum.BEGINED
+        tx._tx_state.tx_id = "test-tx"
+
+        rollback_started = asyncio.Event()
+        rollback_finished = asyncio.Event()
+
+        async def fake_rollback():
+            rollback_started.set()
+            await asyncio.sleep(0.05)
+            tx._tx_state._state = QueryTxStateEnum.ROLLBACKED
+            rollback_finished.set()
+
+        tx.rollback = fake_rollback
+
+        exit_task = asyncio.create_task(tx.__aexit__(None, None, None))
+        await rollback_started.wait()
+        exit_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await exit_task
+
+        await asyncio.wait_for(rollback_finished.wait(), timeout=0.5)
+        assert tx._tx_state._state == QueryTxStateEnum.ROLLBACKED
+
     @pytest.mark.asyncio
     async def test_tx_begin(self, tx: QueryTxContext):
         assert tx.tx_id is None

--- a/ydb/aio/query/transaction.py
+++ b/ydb/aio/query/transaction.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import (
     Optional,
@@ -67,7 +68,7 @@ class QueryTxContext(BaseQueryTxContext["AsyncDriver"]):
             # effort to avoid useless open transactions
             logger.warning("Potentially leaked tx: %s", self._tx_state.tx_id)
             try:
-                await self.rollback()
+                await asyncio.shield(self.rollback())
             except issues.Error:
                 logger.warning("Failed to rollback leaked tx: %s", self._tx_state.tx_id)
 


### PR DESCRIPTION
### Motivation

- Ensure automatic rollback in asynchronous transaction context can't be interrupted by an outer `CancelledError`, which could leave a transaction open on the server.
- Add a focused regression test that reproduces cancellation during `__aexit__` and verifies rollback still completes.

### Description

- Protect the automatic rollback in `QueryTxContext.__aexit__` with `asyncio.shield(...)` so cancellation of the outer task cannot cancel the rollback (`ydb/aio/query/transaction.py`).
- Add `test_context_manager_shields_rollback_from_cancellation` to `tests/aio/query/test_query_transaction.py` which simulates a running rollback, cancels the `__aexit__` task, expects `CancelledError` to propagate, and asserts the transaction reaches `ROLLBACKED`.
- Modified files: `ydb/aio/query/transaction.py` and `tests/aio/query/test_query_transaction.py`.

### Testing

- Ran the targeted test via `pytest -q tests/aio/query/test_query_transaction.py -k shields_rollback_from_cancellation`, which failed to run in this environment due to test-import issues (`PytestRemovedIn9Warning` raised during `tests/conftest.py` import), so the test could not be executed here (failure).
- The new unit test is included and should run in normal CI or a local dev environment following project setup (`source .venv/bin/activate && tox -e py -- tests/aio/query/test_query_transaction.py -k shields_rollback_from_cancellation`).
